### PR TITLE
feat: add subscription period templates on asset pricing and subscribe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,17 +16,20 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: "npm"
+          cache: pnpm
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Run lint
-        run: npm run lint
+        run: pnpm run lint
 
   abis:
     name: Contract ABIs (up to date)
@@ -59,17 +62,20 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: "npm"
+          cache: pnpm
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Run build
-        run: npm run build
+        run: pnpm run build
 
   test:
     name: Test (Vitest)
@@ -81,17 +87,20 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: "npm"
+          cache: pnpm
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Run tests
-        run: npm test
+        run: pnpm test
 
   integration:
     name: Integration Tests (Anvil + Forge)
@@ -103,14 +112,17 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: "npm"
+          cache: pnpm
 
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -123,5 +135,4 @@ jobs:
           export PATH="$HOME/.foundry/bin:$HOME/.cargo/bin:$PATH"
           anvil --version
           forge --version
-          npm run test:integration
-
+          pnpm run test:integration

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,6 @@ pnpm-debug.log*
 # misc
 *.tsbuildinfo
 
-act.tgzcoverage/
+act.tgz
+
+coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ pnpm-debug.log*
 # misc
 *.tsbuildinfo
 
-act.tgz
+act.tgzcoverage/

--- a/README.md
+++ b/README.md
@@ -63,6 +63,36 @@ const token = await sdk.Asset.getTokenAddress({ assetAddress });
 // Asset reads (bound client form)
 const asset = sdk.getAsset({ assetAddress }); // or: await sdk.getAssetById({ assetId })
 await asset.setSubscriptionPrice({ newSubscriptionPrice: 123n });
+
+// Optional period templates (day, week, month, year) instead of raw period-count
+const weekPrice = await asset.getSubscriptionPrice({ period: "week" });
+const quote = await asset.getSubscriptionQuote({ period: "month" });
+// quote.count, quote.price, quote.duration — use quote.price for ERC-2612 permit value
+```
+
+### Subscription period templates
+
+Assets bill in multiples of their on-chain period (`getSubscriptionDuration()`). Pass **`period`** instead of **`count`** on Asset pricing and subscribe helpers:
+
+| `period` | Wall-clock length (fixed) |
+|----------|---------------------------|
+| `day`    | 86,400 s (1 day)          |
+| `week`   | 604,800 s (7 days)        |
+| `month`  | 2,592,000 s (30 days)     |
+| `year`   | 31,536,000 s (365 days)   |
+
+The SDK converts a template into the smallest on-chain **period-count** that covers at least that length. Pass **either** `count` **or** `period`, not both.
+
+```ts
+await asset.subscribe({
+  subscriberId: "alice",
+  subscriberAddress: user,
+  payer: user,
+  spender: assetAddress,
+  period: "month",
+  deadline,
+  v, r, s,
+});
 ```
 
 ### Write methods (require `walletClient`)

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint src --max-warnings=0",
     "test": "vitest run src/test/unit",
+    "test:coverage": "vitest run src/test/unit --coverage",
     "test:integration": "RUN_INTEGRATION_TESTS=1 vitest run src/test/integration",
     "abis:sync": "node scripts/sync-contract-abis.mjs",
     "abis:check": "node scripts/sync-contract-abis.mjs --check",
@@ -45,6 +46,7 @@
     "@typescript-eslint/parser": "^8.57.1",
     "eslint": "^10.0.3",
     "typescript": "^5.3.2",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.0",
+    "@vitest/coverage-v8": "4.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "TypeScript SDK for interacting with Open Creator Rails contracts and indexer.",
   "license": "MIT",
+  "packageManager": "pnpm@10.28.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ChainSafe/open-creator-rails.sdk.git"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.57.1
         version: 8.57.1(eslint@10.0.3)(typescript@5.9.3)
+      '@vitest/coverage-v8':
+        specifier: 4.1.0
+        version: 4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)))
       eslint:
         specifier: ^10.0.3
         version: 10.0.3
@@ -38,6 +41,27 @@ packages:
 
   '@adraffy/ens-normalize@1.11.1':
     resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@emnapi/core@1.9.0':
     resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
@@ -103,8 +127,15 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
@@ -312,6 +343,15 @@ packages:
     resolution: {integrity: sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/coverage-v8@4.1.0':
+    resolution: {integrity: sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==}
+    peerDependencies:
+      '@vitest/browser': 4.1.0
+      vitest: 4.1.0
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.0':
     resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
 
@@ -368,6 +408,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.3:
+    resolution: {integrity: sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -505,6 +548,13 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -532,6 +582,21 @@ packages:
     resolution: {integrity: sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==}
     peerDependencies:
       ws: '*'
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -625,6 +690,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.3:
+    resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
@@ -724,6 +796,10 @@ packages:
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -884,6 +960,21 @@ snapshots:
 
   '@adraffy/ens-normalize@1.11.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
+
   '@emnapi/core@1.9.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.0
@@ -945,7 +1036,14 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
@@ -1143,6 +1241,20 @@ snapshots:
       '@typescript-eslint/types': 8.57.1
       eslint-visitor-keys: 5.0.1
 
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0)))':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.0
+      ast-v8-to-istanbul: 1.0.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.3
+      obug: 2.1.1
+      std-env: 4.0.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.0(@types/node@25.5.0)(vite@8.0.0(@types/node@25.5.0))
+
   '@vitest/expect@4.1.0':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -1202,6 +1314,12 @@ snapshots:
       uri-js: 4.4.1
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.3:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   balanced-match@4.0.4: {}
 
@@ -1336,6 +1454,10 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  has-flag@4.0.0: {}
+
+  html-escaper@2.0.2: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -1353,6 +1475,21 @@ snapshots:
   isows@1.0.7(ws@8.18.3):
     dependencies:
       ws: 8.18.3
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  js-tokens@10.0.0: {}
 
   json-buffer@3.0.1: {}
 
@@ -1425,6 +1562,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   minimatch@10.2.4:
     dependencies:
@@ -1526,6 +1673,10 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@4.0.0: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   tinybench@2.9.0: {}
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -14,6 +14,7 @@ import type {
   SubscribeParams,
   SubscriptionStatus,
 } from "./types";
+import { resolveSubscriptionCount, type SubscriptionPeriodCountInput } from "./subscriptionPeriod";
 import { subscriberHash } from "./utils";
 
 export class OcrSdk {
@@ -70,11 +71,15 @@ export class OcrSdk {
     getRegistryAddress: (params: { assetAddress: Address }) => Promise<Address>;
     getTokenAddress: (params: { assetAddress: Address }) => Promise<Address>;
     getSubscriptionDuration: (params: { assetAddress: Address }) => Promise<bigint>;
-    getSubscriptionPrice: (params: { assetAddress: Address; count: bigint }) => Promise<bigint>;
+    getSubscriptionPrice: (params: {
+      assetAddress: Address;
+    } & SubscriptionPeriodCountInput) => Promise<bigint>;
     getSubscriptionPriceAndDuration: (params: {
       assetAddress: Address;
-      count: bigint;
-    }) => Promise<{ price: bigint; duration: bigint }>;
+    } & SubscriptionPeriodCountInput) => Promise<{ price: bigint; duration: bigint }>;
+    getSubscriptionQuote: (params: {
+      assetAddress: Address;
+    } & SubscriptionPeriodCountInput) => Promise<{ count: bigint; price: bigint; duration: bigint }>;
     getSubscription: (params: {
       assetAddress: Address;
       subscriberId: string;
@@ -102,12 +107,11 @@ export class OcrSdk {
       subscriberAddress: Address;
       payer: Address;
       spender: Address;
-      count: bigint;
       deadline: bigint;
       v: number;
       r: Hex;
       s: Hex;
-    }) => Promise<Hex>;
+    } & SubscriptionPeriodCountInput) => Promise<Hex>;
     claimCreatorFee: (params: ClaimCreatorFeeParams) => Promise<Hex>;
     claimCreatorFeeBatch: (params: { assetAddress: Address; subscribers: readonly Hex[] }) => Promise<Hex>;
     claimRegistryFee: (params: ManageSubscriptionParams) => Promise<Hex>;
@@ -166,6 +170,7 @@ export class OcrSdk {
       getSubscriptionDuration: (params) => this.getAssetSubscriptionDuration(params),
       getSubscriptionPrice: (params) => this.getAssetSubscriptionPrice(params),
       getSubscriptionPriceAndDuration: (params) => this.getAssetSubscriptionPriceAndDuration(params),
+      getSubscriptionQuote: (params) => this.getAssetSubscriptionQuote(params),
       getSubscription: (params) => this.getAssetSubscription(params),
       getSubscriptionStatus: (params) => this.getAssetSubscriptionStatus(params),
       isSubscriptionActive: (params) => this.isAssetSubscriptionActive(params),
@@ -193,6 +198,14 @@ export class OcrSdk {
 
   private subscriberBytes32(params: { subscriberId: string; user: Address }): Hex {
     return subscriberHash(params.subscriberId, params.user);
+  }
+
+  private async resolveAssetSubscriptionCount(
+    assetAddress: Address,
+    params: SubscriptionPeriodCountInput,
+  ): Promise<bigint> {
+    const assetPeriodSeconds = await this.getAssetSubscriptionDuration({ assetAddress });
+    return resolveSubscriptionCount(params, assetPeriodSeconds);
   }
 
   async getSubscriptionStatus(params: AccessCheckParams): Promise<SubscriptionStatus> {
@@ -223,9 +236,10 @@ export class OcrSdk {
       getRegistryAddress: () => this.Asset.getRegistryAddress({ assetAddress }),
       getTokenAddress: () => this.Asset.getTokenAddress({ assetAddress }),
       getSubscriptionDuration: () => this.Asset.getSubscriptionDuration({ assetAddress }),
-      getSubscriptionPrice: ({ count }) => this.Asset.getSubscriptionPrice({ assetAddress, count }),
-      getSubscriptionPriceAndDuration: ({ count }) =>
-        this.Asset.getSubscriptionPriceAndDuration({ assetAddress, count }),
+      getSubscriptionPrice: (params) => this.Asset.getSubscriptionPrice({ assetAddress, ...params }),
+      getSubscriptionPriceAndDuration: (params) =>
+        this.Asset.getSubscriptionPriceAndDuration({ assetAddress, ...params }),
+      getSubscriptionQuote: (params) => this.Asset.getSubscriptionQuote({ assetAddress, ...params }),
       getSubscription: ({ subscriberId, subscriberAddress }) =>
         this.Asset.getSubscription({ assetAddress, subscriberId, subscriberAddress }),
       getSubscriptionStatus: ({ subscriberId, user, source }) =>
@@ -644,26 +658,42 @@ export class OcrSdk {
     })) as bigint;
   }
 
-  async getAssetSubscriptionPrice(params: { assetAddress: Address; count: bigint }): Promise<bigint> {
+  async getAssetSubscriptionPrice(
+    params: { assetAddress: Address } & SubscriptionPeriodCountInput,
+  ): Promise<bigint> {
+    const count = await this.resolveAssetSubscriptionCount(params.assetAddress, params);
     return (await this.publicClient.readContract({
       address: params.assetAddress,
       abi: AssetABI,
       functionName: "getSubscriptionPrice",
-      args: [params.count],
+      args: [count],
     })) as bigint;
   }
 
-  async getAssetSubscriptionPriceAndDuration(params: {
-    assetAddress: Address;
-    count: bigint;
-  }): Promise<{ price: bigint; duration: bigint }> {
+  async getAssetSubscriptionPriceAndDuration(
+    params: { assetAddress: Address } & SubscriptionPeriodCountInput,
+  ): Promise<{ price: bigint; duration: bigint }> {
+    const count = await this.resolveAssetSubscriptionCount(params.assetAddress, params);
     const [price, duration] = (await this.publicClient.readContract({
       address: params.assetAddress,
       abi: AssetABI,
       functionName: "getSubscriptionPriceAndDuration",
-      args: [params.count],
+      args: [count],
     })) as [bigint, bigint];
     return { price, duration };
+  }
+
+  async getAssetSubscriptionQuote(
+    params: { assetAddress: Address } & SubscriptionPeriodCountInput,
+  ): Promise<{ count: bigint; price: bigint; duration: bigint }> {
+    const count = await this.resolveAssetSubscriptionCount(params.assetAddress, params);
+    const [price, duration] = (await this.publicClient.readContract({
+      address: params.assetAddress,
+      abi: AssetABI,
+      functionName: "getSubscriptionPriceAndDuration",
+      args: [count],
+    })) as [bigint, bigint];
+    return { count, price, duration };
   }
 
   async getAssetSubscription(params: {
@@ -759,19 +789,21 @@ export class OcrSdk {
     return this.getAssetOwner({ assetAddress: params.assetAddress });
   }
 
-  async subscribeToAsset(params: {
-    assetAddress: Address;
-    subscriberId: string;
-    subscriberAddress: Address;
-    payer: Address;
-    spender: Address;
-    count: bigint;
-    deadline: bigint;
-    v: number;
-    r: Hex;
-    s: Hex;
-  }) {
+  async subscribeToAsset(
+    params: {
+      assetAddress: Address;
+      subscriberId: string;
+      subscriberAddress: Address;
+      payer: Address;
+      spender: Address;
+      deadline: bigint;
+      v: number;
+      r: Hex;
+      s: Hex;
+    } & SubscriptionPeriodCountInput,
+  ) {
     const { walletClient, account } = this.getWalletContext();
+    const count = await this.resolveAssetSubscriptionCount(params.assetAddress, params);
     const sub = subscriberHash(params.subscriberId, params.subscriberAddress);
     return walletClient.writeContract({
       address: params.assetAddress,
@@ -779,7 +811,7 @@ export class OcrSdk {
       functionName: "subscribe",
       chain: walletClient.chain ?? null,
       account,
-      args: [sub, params.payer, params.spender, params.count, params.deadline, params.v, params.r, params.s],
+      args: [sub, params.payer, params.spender, count, params.deadline, params.v, params.r, params.s],
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export * from "./abis";
 export * from "./indexer";
 export * from "./types";
 export * from "./utils";
+export * from "./subscriptionPeriod";

--- a/src/subscriptionPeriod.ts
+++ b/src/subscriptionPeriod.ts
@@ -1,0 +1,52 @@
+/**
+ * Wall-clock subscription period templates (fixed second lengths, not calendar months).
+ *
+ * - `month` = 30 days, `year` = 365 days (common billing approximations).
+ * - On-chain assets bill in multiples of the asset's configured period (`getSubscriptionDuration()`).
+ * - `period: "month"` resolves to enough period-count to cover ~30 days of access.
+ */
+export const SUBSCRIPTION_PERIOD_SECONDS = {
+  day: 86_400n,
+  week: 604_800n,
+  month: 2_592_000n,
+  year: 31_536_000n,
+} as const;
+
+export type SubscriptionPeriod = keyof typeof SUBSCRIPTION_PERIOD_SECONDS;
+
+/** Pass exactly one of `count` or `period`. */
+export type SubscriptionPeriodCountInput =
+  | { count: bigint; period?: undefined }
+  | { count?: undefined; period: SubscriptionPeriod };
+
+export function subscriptionPeriodToSeconds(period: SubscriptionPeriod): bigint {
+  return SUBSCRIPTION_PERIOD_SECONDS[period];
+}
+
+/** Period-count on chain to cover at least `period` template length. */
+export function countForSubscriptionPeriod(period: SubscriptionPeriod, assetPeriodSeconds: bigint): bigint {
+  if (assetPeriodSeconds <= 0n) {
+    throw new Error("Asset subscription duration must be positive");
+  }
+  const target = subscriptionPeriodToSeconds(period);
+  return (target + assetPeriodSeconds - 1n) / assetPeriodSeconds;
+}
+
+export function resolveSubscriptionCount(
+  input: SubscriptionPeriodCountInput,
+  assetPeriodSeconds: bigint,
+): bigint {
+  if (input.period != null) {
+    if (input.count != null) {
+      throw new Error("Pass either count or period, not both");
+    }
+    return countForSubscriptionPeriod(input.period, assetPeriodSeconds);
+  }
+  if (input.count == null) {
+    throw new Error("count or period is required");
+  }
+  if (input.count < 1n) {
+    throw new Error("count must be at least 1");
+  }
+  return input.count;
+}

--- a/src/test/integration/client.integration.test.ts
+++ b/src/test/integration/client.integration.test.ts
@@ -365,6 +365,96 @@ describeIntegration("OcrSdk integration (anvil + real contracts)", () => {
     expect((status.endTime as bigint) > after.timestamp).toBe(true);
   }, 60_000);
 
+  it("subscribes via asset contract using period template", async () => {
+    if (!anvil) throw new Error("Integration environment not initialized");
+
+    const chain = {
+      id: TEST_CHAIN_ID,
+      name: "anvil",
+      nativeCurrency: { name: "ETH", symbol: "ETH", decimals: 18 },
+      rpcUrls: { default: { http: [anvil.rpcUrl] } },
+    } as any;
+
+    const walletPayer = createWalletClient({
+      chain,
+      transport: http(anvil.rpcUrl),
+      account: privateKeyToAccount(payer.privateKey),
+    }) as any;
+
+    const sdk = new OcrSdk({
+      publicClient: publicClient as any,
+      walletClient: walletPayer as any,
+      registryAddress,
+    } as any);
+
+    const quote = await sdk.getAsset({ assetAddress }).getSubscriptionQuote({ period: "week" });
+    const expectedCount = 604_800n / subscriptionDurationSeconds;
+    expect(quote.count).toBe(expectedCount);
+    expect(quote.duration).toBe(subscriptionDurationSeconds * expectedCount);
+
+    const latest = await publicClient.getBlock({ blockTag: "latest" });
+    const deadline = latest.timestamp + quote.duration;
+
+    const nonce = (await publicClient.readContract({
+      address: tokenAddress,
+      abi: testTokenAbi,
+      functionName: "nonces",
+      args: [payer.address],
+    })) as bigint;
+
+    const tokenName = (await publicClient.readContract({
+      address: tokenAddress,
+      abi: testTokenAbi,
+      functionName: "name",
+    })) as string;
+
+    const chainId = await publicClient.getChainId();
+
+    const signature = await signTypedData({
+      privateKey: payer.privateKey,
+      domain: {
+        name: tokenName,
+        version: "1",
+        chainId,
+        verifyingContract: tokenAddress,
+      },
+      types: permitTypes as any,
+      primaryType: "Permit",
+      message: {
+        owner: payer.address,
+        spender: assetAddress,
+        value: quote.price,
+        nonce,
+        deadline,
+      } as any,
+    });
+
+    const { v, r, s } = splitSignature(signature as `0x${string}`);
+
+    await sdk.subscribeToAsset({
+      assetAddress,
+      subscriberId: `${INTEGRATION_SUBSCRIBER_ID}_period`,
+      subscriberAddress: payer.address,
+      payer: payer.address,
+      spender: assetAddress,
+      period: "week",
+      deadline,
+      v,
+      r,
+      s,
+    });
+
+    const status = await sdk.getAssetSubscriptionStatus({
+      assetAddress,
+      subscriberId: `${INTEGRATION_SUBSCRIBER_ID}_period`,
+      user: payer.address,
+      source: "onchain",
+    });
+
+    expect(status.isActive).toBe(true);
+    expect(status.endTime).toBeDefined();
+  }, 60_000);
+
   it("allows asset owner to claim creator fees after expiry", async () => {
     if (!anvil) throw new Error("Integration environment not initialized");
 

--- a/src/test/unit/client.test.ts
+++ b/src/test/unit/client.test.ts
@@ -43,6 +43,31 @@ function createMockWalletClient(withAccount: boolean = true): WalletClient {
   } as unknown as WalletClient;
 }
 
+describe("OcrSdk constructor", () => {
+  it("requires chain id when indexerUrl is set without publicClient.chain", () => {
+    const publicClient = { readContract: vi.fn(), chain: undefined } as unknown as PublicClient;
+    expect(
+      () =>
+        new OcrSdk({
+          publicClient,
+          registryAddress: mockAddress(),
+          indexerUrl: "https://indexer.test",
+        }),
+    ).toThrow(/chain id/i);
+  });
+
+  it("accepts explicit chainId for indexer", () => {
+    const publicClient = { readContract: vi.fn(), chain: undefined } as unknown as PublicClient;
+    const sdk = new OcrSdk({
+      publicClient,
+      registryAddress: mockAddress(),
+      indexerUrl: "https://indexer.test",
+      chainId: 11155111,
+    });
+    expect(sdk.indexer).toBeDefined();
+  });
+});
+
 describe("OcrSdk.getSubscriptionStatus", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -1280,6 +1305,188 @@ describe("OcrSdk full method coverage", () => {
     await sdk.Asset.getTokenAddress({ assetAddress });
     expect(publicClient.readContract).toHaveBeenLastCalledWith(
       expect.objectContaining({ address: assetAddress, functionName: "getTokenAddress" }),
+    );
+  });
+});
+
+describe("OcrSdk subscription period templates", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("getAssetSubscriptionPrice uses period to derive on-chain period-count", async () => {
+    const publicClient = createMockPublicClient();
+    const sdk = new OcrSdk({
+      publicClient,
+      registryAddress: mockAddress("0xreg"),
+    });
+    const assetAddress = mockAddress("0xasset");
+
+    (publicClient.readContract as any)
+      .mockResolvedValueOnce(86_400n)
+      .mockResolvedValueOnce(9_999n);
+
+    const price = await sdk.Asset.getSubscriptionPrice({ assetAddress, period: "week" });
+
+    expect(price).toBe(9_999n);
+    expect(publicClient.readContract).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        address: assetAddress,
+        functionName: "getSubscriptionPrice",
+        args: [7n],
+      }),
+    );
+  });
+
+  it("getAsset bound client supports period on subscribe", async () => {
+    const publicClient = createMockPublicClient();
+    const walletClient = createMockWalletClient();
+    const sdk = new OcrSdk({
+      publicClient,
+      walletClient,
+      registryAddress: mockAddress("0xreg"),
+    });
+    const assetAddress = mockAddress("0xasset");
+    const user = mockAddress("0xuser");
+    const subHash = subscriberHash(TEST_SUBSCRIBER_ID, user);
+
+    (publicClient.readContract as any).mockResolvedValueOnce(86_400n);
+    (walletClient.writeContract as any).mockResolvedValue("0xtxhash");
+
+    const asset = sdk.getAsset({ assetAddress });
+    await asset.subscribe({
+      subscriberId: TEST_SUBSCRIBER_ID,
+      subscriberAddress: user,
+      payer: user,
+      spender: assetAddress,
+      period: "day",
+      deadline: 100n,
+      v: 27,
+      r: mockHex("0xr"),
+      s: mockHex("0xs"),
+    });
+
+    expect(walletClient.writeContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: assetAddress,
+        functionName: "subscribe",
+        args: [subHash, user, assetAddress, 1n, 100n, 27, mockHex("0xr"), mockHex("0xs")],
+      }),
+    );
+  });
+
+  it("subscribeToAsset resolves period to on-chain count", async () => {
+    const publicClient = createMockPublicClient();
+    const walletClient = createMockWalletClient();
+    const sdk = new OcrSdk({
+      publicClient,
+      walletClient,
+      registryAddress: mockAddress("0xreg"),
+    });
+    const assetAddress = mockAddress("0xasset");
+    const user = mockAddress("0xuser");
+    const subHash = subscriberHash(TEST_SUBSCRIBER_ID, user);
+
+    (publicClient.readContract as any).mockResolvedValueOnce(86_400n);
+    (walletClient.writeContract as any).mockResolvedValue("0xtxhash");
+
+    await sdk.subscribeToAsset({
+      assetAddress,
+      subscriberId: TEST_SUBSCRIBER_ID,
+      subscriberAddress: user,
+      payer: user,
+      spender: assetAddress,
+      period: "week",
+      deadline: 50n,
+      v: 27,
+      r: mockHex("0xr"),
+      s: mockHex("0xs"),
+    });
+
+    expect(walletClient.writeContract).toHaveBeenCalledWith(
+      expect.objectContaining({
+        functionName: "subscribe",
+        args: [subHash, user, assetAddress, 7n, 50n, 27, mockHex("0xr"), mockHex("0xs")],
+      }),
+    );
+  });
+
+  it("getSubscriptionQuote returns count, price, and duration", async () => {
+    const publicClient = createMockPublicClient();
+    const sdk = new OcrSdk({
+      publicClient,
+      registryAddress: mockAddress("0xreg"),
+    });
+    const assetAddress = mockAddress("0xasset");
+
+    (publicClient.readContract as any)
+      .mockResolvedValueOnce(86_400n)
+      .mockResolvedValueOnce([500n, 86_400n]);
+
+    const quote = await sdk.getAsset({ assetAddress }).getSubscriptionQuote({ period: "day" });
+
+    expect(quote).toEqual({ count: 1n, price: 500n, duration: 86_400n });
+  });
+
+  it("getAssetSubscriptionPriceAndDuration resolves period", async () => {
+    const publicClient = createMockPublicClient();
+    const sdk = new OcrSdk({
+      publicClient,
+      registryAddress: mockAddress("0xreg"),
+    });
+    const assetAddress = mockAddress("0xasset");
+
+    (publicClient.readContract as any)
+      .mockResolvedValueOnce(86_400n)
+      .mockResolvedValueOnce([900n, 604_800n]);
+
+    const res = await sdk.getAssetSubscriptionPriceAndDuration({
+      assetAddress,
+      period: "week",
+    });
+
+    expect(res).toEqual({ price: 900n, duration: 604_800n });
+    expect(publicClient.readContract).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        functionName: "getSubscriptionPriceAndDuration",
+        args: [7n],
+      }),
+    );
+  });
+});
+
+describe("OcrSdk batch and registry duration helpers", () => {
+  it("covers registry duration reads and batch fee claims", async () => {
+    const publicClient = createMockPublicClient();
+    const walletClient = createMockWalletClient();
+    const sdk = new OcrSdk({
+      publicClient,
+      walletClient,
+      registryAddress: mockAddress("0xreg"),
+    });
+
+    const assetId = mockHex("0xassetId");
+    const assetAddress = mockAddress("0xasset");
+    const subs = [subscriberHash(TEST_SUBSCRIBER_ID, mockAddress("0xu1"))];
+
+    (publicClient.readContract as any).mockResolvedValueOnce(120n);
+    expect(await sdk.getRegistrySubscriptionDuration({ assetId })).toBe(120n);
+
+    (publicClient.readContract as any).mockResolvedValueOnce([50n, 120n]);
+    expect(await sdk.getRegistrySubscriptionPriceAndDuration({ assetId, count: 2n })).toEqual({
+      price: 50n,
+      duration: 120n,
+    });
+
+    (walletClient.writeContract as any).mockResolvedValue("0xbatch");
+    await sdk.claimCreatorFeeBatch({ assetAddress, subscribers: subs });
+    expect(walletClient.writeContract).toHaveBeenLastCalledWith(
+      expect.objectContaining({ functionName: "claimCreatorFee", args: [subs] }),
+    );
+
+    await sdk.claimRegistryFeeBatchFromRegistry({ assetId, subscribers: subs });
+    expect(walletClient.writeContract).toHaveBeenLastCalledWith(
+      expect.objectContaining({ functionName: "claimRegistryFee", args: [assetId, subs] }),
     );
   });
 });

--- a/src/test/unit/indexer.test.ts
+++ b/src/test/unit/indexer.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getAddress } from "viem";
+import {
+  createSdkIndexer,
+  indexerAssetEntityId,
+  resolveOpenCreatorRailsIndexerGraphqlUrl,
+} from "../../indexer";
+import { subscriberHash } from "../../utils";
+
+const CHAIN_ID = 31337;
+const ASSET = getAddress("0xAbCdEf1234567890123456789012345678901234");
+const USER = getAddress("0x00000000000000000000000000000000000000b2");
+const SUBSCRIBER_ID = "indexer_unit_test";
+
+describe("resolveOpenCreatorRailsIndexerGraphqlUrl", () => {
+  it("appends /v2/graphql to a base URL", () => {
+    expect(resolveOpenCreatorRailsIndexerGraphqlUrl("https://ix.example")).toBe(
+      "https://ix.example/v2/graphql",
+    );
+  });
+
+  it("trims whitespace and trailing slashes", () => {
+    expect(resolveOpenCreatorRailsIndexerGraphqlUrl("  https://ix.example/  ")).toBe(
+      "https://ix.example/v2/graphql",
+    );
+  });
+
+  it("upgrades legacy /graphql to /v2/graphql", () => {
+    expect(resolveOpenCreatorRailsIndexerGraphqlUrl("https://ix.example/graphql")).toBe(
+      "https://ix.example/v2/graphql",
+    );
+  });
+
+  it("leaves /v2/graphql unchanged (case-insensitive)", () => {
+    expect(resolveOpenCreatorRailsIndexerGraphqlUrl("https://ix.example/V2/GraphQL")).toBe(
+      "https://ix.example/V2/GraphQL",
+    );
+  });
+});
+
+describe("indexerAssetEntityId", () => {
+  it("formats chainId and lowercased address", () => {
+    expect(indexerAssetEntityId(CHAIN_ID, ASSET)).toBe(
+      `${CHAIN_ID}_${ASSET.toLowerCase()}`,
+    );
+  });
+});
+
+describe("createSdkIndexer", () => {
+  const baseUrl = "https://indexer.test";
+  const endpoint = resolveOpenCreatorRailsIndexerGraphqlUrl(baseUrl);
+  const assetEntityId = indexerAssetEntityId(CHAIN_ID, ASSET);
+  const subHex = subscriberHash(SUBSCRIBER_ID, USER);
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockFetchJson(body: unknown) {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => body,
+    } as any);
+  }
+
+  it("getSubscriptionBySubscriberId maps subscription fields", async () => {
+    mockFetchJson({
+      data: {
+        subscriptions: {
+          items: [
+            {
+              id: `${assetEntityId}_${subHex}_0`,
+              assetId: assetEntityId,
+              startTime: "10",
+              endTime: "20",
+              nonce: "2",
+              isActive: true,
+              payer: USER,
+            },
+          ],
+        },
+      },
+    });
+
+    const ix = createSdkIndexer(baseUrl, { chainId: CHAIN_ID });
+    const row = await ix.getSubscriptionBySubscriberId({
+      assetAddress: ASSET,
+      subscriberHash: subHex,
+    });
+
+    expect(fetch).toHaveBeenCalledWith(endpoint, expect.any(Object));
+    expect(row).toEqual({
+      id: `${assetEntityId}_${subHex}_0`,
+      assetAddress: ASSET,
+      subscriberId: subHex,
+      payer: USER,
+      isActive: true,
+      startTime: 10n,
+      endTime: 20n,
+      nonce: 2n,
+    });
+  });
+
+  it("getSubscriptionBySubscriberId uses zero address when payer is null", async () => {
+    mockFetchJson({
+      data: {
+        subscriptions: {
+          items: [
+            {
+              id: "x",
+              assetId: assetEntityId,
+              startTime: "1",
+              endTime: "2",
+              nonce: "0",
+              isActive: false,
+              payer: null,
+            },
+          ],
+        },
+      },
+    });
+
+    const ix = createSdkIndexer(baseUrl, { chainId: CHAIN_ID });
+    const row = await ix.getSubscriptionBySubscriberId({
+      assetAddress: ASSET,
+      subscriberHash: subHex,
+    });
+
+    expect(row?.payer).toBe(getAddress(`0x${"0".repeat(40)}`));
+  });
+
+  it("getSubscription delegates to subscriber hash lookup", async () => {
+    mockFetchJson({ data: { subscriptions: { items: [] } } });
+
+    const ix = createSdkIndexer(baseUrl, { chainId: CHAIN_ID });
+    const row = await ix.getSubscription({
+      assetAddress: ASSET,
+      subscriberId: SUBSCRIBER_ID,
+      subscriberAddress: USER,
+    });
+
+    expect(row).toBeNull();
+    const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, { body: string }];
+    const body = JSON.parse(init.body as string);
+    expect(body.variables.subscriber).toBe(subHex.toLowerCase());
+  });
+
+  it("getAsset returns null when not indexed", async () => {
+    mockFetchJson({ data: { assets: { items: [] } } });
+
+    const ix = createSdkIndexer(baseUrl, { chainId: CHAIN_ID });
+    expect(await ix.getAsset({ assetAddress: ASSET })).toBeNull();
+  });
+
+  it("getAssetOwner returns owner from asset entity", async () => {
+    const owner = getAddress("0x00000000000000000000000000000000000000c3");
+    mockFetchJson({
+      data: {
+        assets: {
+          items: [
+            {
+              id: assetEntityId,
+              assetId: "0xassetid",
+              registryAddress: getAddress("0x00000000000000000000000000000000000000d4"),
+              owner: owner,
+              address: ASSET.toLowerCase(),
+            },
+          ],
+        },
+      },
+    });
+
+    const ix = createSdkIndexer(baseUrl, { chainId: CHAIN_ID });
+    expect(await ix.getAssetOwner({ assetAddress: ASSET })).toBe(owner);
+  });
+
+  it("listSubscriptionsBySubscriberId queries activeSubscriptions when activeOnly", async () => {
+    mockFetchJson({
+      data: {
+        activeSubscriptions: {
+          items: [
+            {
+              id: "s1",
+              assetId: assetEntityId,
+              subscriber: subHex,
+              payer: USER,
+              startTime: "1",
+              endTime: "2",
+              nonce: "0",
+              isActive: true,
+            },
+          ],
+        },
+      },
+    });
+
+    const ix = createSdkIndexer(baseUrl, { chainId: CHAIN_ID });
+    const rows = await ix.listSubscriptionsBySubscriberId({
+      subscriberHash: subHex,
+      activeOnly: true,
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.assetAddress).toBe(ASSET);
+    const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, { body: string }];
+    expect(init.body as string).toContain("activeSubscriptions");
+  });
+
+  it("listSubscriptionsBySubscriberId queries subscriptions when not activeOnly", async () => {
+    mockFetchJson({ data: { subscriptions: { items: [] } } });
+
+    const ix = createSdkIndexer(baseUrl, { chainId: CHAIN_ID });
+    await ix.listSubscriptionsBySubscriberId({ subscriberHash: subHex, activeOnly: false });
+
+    const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, { body: string }];
+    expect(init.body as string).toContain("subscriptions(");
+    expect(init.body as string).not.toContain("activeSubscriptions");
+  });
+
+  it("listAssetsByRegistry maps asset rows", async () => {
+    const registry = getAddress("0x00000000000000000000000000000000000000e5");
+    mockFetchJson({
+      data: {
+        assets: {
+          items: [
+            {
+              id: assetEntityId,
+              assetId: "0xaid",
+              registryAddress: registry,
+              owner: USER,
+              address: ASSET.toLowerCase(),
+            },
+          ],
+        },
+      },
+    });
+
+    const ix = createSdkIndexer(baseUrl, { chainId: CHAIN_ID });
+    const rows = await ix.listAssetsByRegistry({ registryAddress: registry });
+    expect(rows[0]?.id).toBe(ASSET.toLowerCase());
+    expect(rows[0]).toMatchObject({
+      assetId: "0xaid",
+      registryAddress: registry,
+      owner: USER,
+    });
+  });
+
+  it("throws on invalid asset entity id in subscription list", async () => {
+    mockFetchJson({
+      data: {
+        subscriptions: {
+          items: [
+            {
+              id: "bad",
+              assetId: "not-an-entity-id",
+              subscriber: subHex,
+              payer: USER,
+              startTime: "1",
+              endTime: "2",
+              nonce: "0",
+              isActive: true,
+            },
+          ],
+        },
+      },
+    });
+
+    const ix = createSdkIndexer(baseUrl, { chainId: CHAIN_ID });
+    await expect(
+      ix.listSubscriptionsBySubscriberId({ subscriberHash: subHex }),
+    ).rejects.toThrow(/Invalid asset entity id/);
+  });
+});

--- a/src/test/unit/subscriptionPeriod.test.ts
+++ b/src/test/unit/subscriptionPeriod.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import {
+  SUBSCRIPTION_PERIOD_SECONDS,
+  countForSubscriptionPeriod,
+  resolveSubscriptionCount,
+  subscriptionPeriodToSeconds,
+} from "../../subscriptionPeriod";
+
+describe("subscriptionPeriod", () => {
+  it("maps day, week, month, year to fixed seconds", () => {
+    expect(subscriptionPeriodToSeconds("day")).toBe(86_400n);
+    expect(subscriptionPeriodToSeconds("week")).toBe(604_800n);
+    expect(subscriptionPeriodToSeconds("month")).toBe(2_592_000n);
+    expect(subscriptionPeriodToSeconds("year")).toBe(31_536_000n);
+  });
+
+  it("computes period count to cover template length (ceil division)", () => {
+    expect(countForSubscriptionPeriod("day", 86_400n)).toBe(1n);
+    expect(countForSubscriptionPeriod("week", 86_400n)).toBe(7n);
+    expect(countForSubscriptionPeriod("month", 86_400n)).toBe(30n);
+    expect(countForSubscriptionPeriod("year", 2_592_000n)).toBe(13n);
+  });
+
+  it("resolveSubscriptionCount uses count when provided", () => {
+    expect(resolveSubscriptionCount({ count: 3n }, 86_400n)).toBe(3n);
+  });
+
+  it("resolveSubscriptionCount derives count from period", () => {
+    expect(resolveSubscriptionCount({ period: "week" }, 86_400n)).toBe(7n);
+  });
+
+  it("rejects count and period together", () => {
+    expect(() =>
+      resolveSubscriptionCount({ count: 1n, period: "day" }, 86_400n),
+    ).toThrow(/either count or period/i);
+  });
+
+  it("rejects missing count and period", () => {
+    expect(() => resolveSubscriptionCount({}, 86_400n)).toThrow(/count or period is required/i);
+  });
+
+  it("documents month as 30 days", () => {
+    expect(SUBSCRIPTION_PERIOD_SECONDS.month).toBe(30n * SUBSCRIPTION_PERIOD_SECONDS.day);
+  });
+
+  it("rejects zero or negative asset period seconds", () => {
+    expect(() => countForSubscriptionPeriod("day", 0n)).toThrow(/must be positive/i);
+    expect(() => countForSubscriptionPeriod("week", -1n)).toThrow(/must be positive/i);
+  });
+
+  it("rejects count below 1", () => {
+    expect(() => resolveSubscriptionCount({ count: 0n }, 86_400n)).toThrow(/at least 1/i);
+  });
+});

--- a/src/test/unit/utils.test.ts
+++ b/src/test/unit/utils.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { encodeAbiParameters, getAddress, keccak256 } from "viem";
+import {
+  asAddress,
+  asHex,
+  cancelSubscriptionDigest,
+  graphql,
+  subscriberHash,
+} from "../../utils";
+
+const CHAIN_ID = 31337;
+const ASSET = getAddress("0x00000000000000000000000000000000000000a1");
+const USER = getAddress("0x00000000000000000000000000000000000000b2");
+
+describe("subscriberHash", () => {
+  it("is deterministic for the same subscriber id and address", () => {
+    const a = subscriberHash("user-1", USER);
+    const b = subscriberHash("user-1", USER);
+    expect(a).toBe(b);
+    expect(a).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+
+  it("differs when subscriber id or address changes", () => {
+    const base = subscriberHash("user-1", USER);
+    expect(subscriberHash("user-2", USER)).not.toBe(base);
+    expect(subscriberHash("user-1", getAddress("0x00000000000000000000000000000000000000c3"))).not.toBe(
+      base,
+    );
+  });
+
+  it("matches viem abi.encode + keccak256", () => {
+    const id = "integration_subscriber";
+    const expected = keccak256(
+      encodeAbiParameters(
+        [
+          { type: "string", name: "subscriberId" },
+          { type: "address", name: "subscriberAddress" },
+        ],
+        [id, USER],
+      ),
+    );
+    expect(subscriberHash(id, USER)).toBe(expected);
+  });
+});
+
+describe("cancelSubscriptionDigest", () => {
+  it("packs chain id, asset address, and subscriber hash", () => {
+    const subscriber = subscriberHash("sub", USER);
+    const digest = cancelSubscriptionDigest(CHAIN_ID, ASSET, subscriber);
+    expect(digest).toMatch(/^0x[0-9a-f]{64}$/);
+    expect(cancelSubscriptionDigest(CHAIN_ID, ASSET, subscriber)).toBe(digest);
+    expect(cancelSubscriptionDigest(CHAIN_ID + 1, ASSET, subscriber)).not.toBe(digest);
+  });
+});
+
+describe("asAddress / asHex", () => {
+  it("accepts valid strings", () => {
+    expect(asAddress(ASSET)).toBe(ASSET);
+    expect(asHex("0xabc")).toBe("0xabc");
+  });
+
+  it("rejects non-string values", () => {
+    expect(() => asAddress(1)).toThrow("Expected address string");
+    expect(() => asHex(null)).toThrow("Expected hex string");
+  });
+});
+
+describe("graphql", () => {
+  const endpoint = "https://indexer.test/v2/graphql";
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns data on success", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { ok: true } }),
+    } as any);
+
+    const data = await graphql<{ ok: boolean }>(endpoint, "query {}", {});
+    expect(data).toEqual({ ok: true });
+    expect(fetch).toHaveBeenCalledWith(
+      endpoint,
+      expect.objectContaining({
+        method: "POST",
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  });
+
+  it("throws on non-OK HTTP status", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    } as any);
+
+    await expect(graphql(endpoint, "query {}", {})).rejects.toThrow(
+      "Indexer request failed with status 503",
+    );
+  });
+
+  it("throws with GraphQL error messages", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        errors: [{ message: "bad field" }, { message: "other" }],
+      }),
+    } as any);
+
+    await expect(graphql(endpoint, "query {}", {})).rejects.toThrow(
+      "Indexer GraphQL error: bad field; other",
+    );
+  });
+
+  it("throws generic GraphQL error when messages are missing", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ errors: [{}] }),
+    } as any);
+
+    await expect(graphql(endpoint, "query {}", {})).rejects.toThrow("Indexer GraphQL error");
+  });
+
+  it("throws when response has no data", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as any);
+
+    await expect(graphql(endpoint, "query {}", {})).rejects.toThrow(
+      "Indexer response missing data",
+    );
+  });
+});

--- a/src/types/sdk.ts
+++ b/src/types/sdk.ts
@@ -1,4 +1,7 @@
 import type { Address, Hex, PublicClient, WalletClient } from "viem";
+import type { SubscriptionPeriod, SubscriptionPeriodCountInput } from "../subscriptionPeriod";
+
+export type { SubscriptionPeriod, SubscriptionPeriodCountInput };
 
 export interface OcrSdkConfig {
   /** Onchain read client (required). */
@@ -19,10 +22,14 @@ export type OcrAssetClient = {
   getRegistryAddress: () => Promise<Address>;
   getTokenAddress: () => Promise<Address>;
   getSubscriptionDuration: () => Promise<bigint>;
-  getSubscriptionPrice: (params: { count: bigint }) => Promise<bigint>;
-  getSubscriptionPriceAndDuration: (params: {
-    count: bigint;
-  }) => Promise<{ price: bigint; duration: bigint }>;
+  getSubscriptionPrice: (params: SubscriptionPeriodCountInput) => Promise<bigint>;
+  getSubscriptionPriceAndDuration: (
+    params: SubscriptionPeriodCountInput,
+  ) => Promise<{ price: bigint; duration: bigint }>;
+  /** Resolves `count` from optional `period`, then returns on-chain price and total duration. */
+  getSubscriptionQuote: (
+    params: SubscriptionPeriodCountInput,
+  ) => Promise<{ count: bigint; price: bigint; duration: bigint }>;
   getSubscription: (params: { subscriberId: string; subscriberAddress: Address }) => Promise<bigint>;
   getSubscriptionStatus: (params: {
     subscriberId: string;
@@ -37,12 +44,11 @@ export type OcrAssetClient = {
     subscriberAddress: Address;
     payer: Address;
     spender: Address;
-    count: bigint;
     deadline: bigint;
     v: number;
     r: Hex;
     s: Hex;
-  }) => Promise<Hex>;
+  } & SubscriptionPeriodCountInput) => Promise<Hex>;
   claimCreatorFee: (params: { subscriberId: string; subscriberAddress: Address }) => Promise<Hex>;
   claimCreatorFeeBatch: (params: { subscribers: readonly Hex[] }) => Promise<Hex>;
   claimRegistryFee: (params: { subscriberId: string; subscriberAddress: Address }) => Promise<Hex>;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/test/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.ts"],
+      exclude: [
+        "src/test/**",
+        "src/config/**",
+        "src/index.ts",
+        "src/abis.ts",
+        "src/types/**",
+      ],
+      thresholds: {
+        lines: 75,
+        functions: 55,
+        branches: 75,
+        statements: 75,
+      },
+    },
+  },
+});


### PR DESCRIPTION
Closes #27 

- Asset pricing/subscribe: optional period (day / week / month / year) instead of count
- SDK maps templates → on-chain period-count via the asset’s getSubscriptionDuration()
- New helpers: subscriptionPeriod module, getSubscriptionQuote
- Registry subscribe unchanged; existing count calls still work
- More unit + integration tests; pnpm test:coverage + vitest config
- README updated; demo changes not required